### PR TITLE
Add Istanbul locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "build:images": "node resources/prepare-images.js",
     "install": "node scripts/link.js",
     "test": "node node_modules/nodeunit/bin/nodeunit tests tests/integration",
-    "test:junit": "node node_modules/nodeunit/bin/nodeunit tests tests/integration --reporter junit --output build"
+    "test:junit": "node node_modules/nodeunit/bin/nodeunit tests tests/integration --reporter junit --output build",
+		"test:istanbul": "node node_modules/istanbul/lib/cli.js cover node_modules/nodeunit/bin/nodeunit tests tests/integration"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,54 +1,55 @@
 {
-	"name": "buttercup",
-	"version": "0.14.0",
-	"description": "A NodeJS password vault.",
-	"main": "source/module.js",
-	"contributors": [
-		{
-			"name": "Perry Mitchell",
-			"email": "perry@perrymitchell.net"
-		},
-		{
-			"name": "Sallar Kaboli",
-			"email": "sallar.kaboli@gmail.com"
-		}
-	],
-	"scripts": {
-		"build:images": "node resources/prepare-images.js",
-		"install": "node scripts/link.js",
-		"test": "node node_modules/nodeunit/bin/nodeunit tests tests/integration",
-		"test:junit": "node node_modules/nodeunit/bin/nodeunit tests tests/integration --reporter junit --output build"
-	},
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/perry-mitchell/buttercup-core"
-	},
-	"keywords": [
-		"password",
-		"vault",
-		"credentials",
-		"login",
-		"secure"
-	],
-	"author": "Perry Mitchell <perry@perrymitchell.net>",
-	"license": "MIT",
-	"bugs": {
-		"url": "https://github.com/perry-mitchell/buttercup-core/issues"
-	},
-	"homepage": "https://github.com/perry-mitchell/buttercup-core#readme",
-	"dependencies": {
-		"clone":						"~1.0.2",
-		"fs-symlink":					"~1.2.1",
-		"gzip-js":						"~0.3.2",
-		"pbkdf2": 						"~3.0.4",
-		"promise-polyfill":				"~2.1.0",
-		"uuid":							"~2.0.1",
-		"webdav-fs":					"~0.3.0"
-	},
-	"devDependencies": {
-    	"base64-img":					"~1.0.3",
-		"jsdoc-to-markdown": 			"~1.2.0",
-		"nodeunit": 					"~0.9.1",
-    	"walk": 						"~2.3.9"
-	}
+  "name": "buttercup",
+  "version": "0.14.0",
+  "description": "A NodeJS password vault.",
+  "main": "source/module.js",
+  "contributors": [
+    {
+      "name": "Perry Mitchell",
+      "email": "perry@perrymitchell.net"
+    },
+    {
+      "name": "Sallar Kaboli",
+      "email": "sallar.kaboli@gmail.com"
+    }
+  ],
+  "scripts": {
+    "build:images": "node resources/prepare-images.js",
+    "install": "node scripts/link.js",
+    "test": "node node_modules/nodeunit/bin/nodeunit tests tests/integration",
+    "test:junit": "node node_modules/nodeunit/bin/nodeunit tests tests/integration --reporter junit --output build"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/perry-mitchell/buttercup-core"
+  },
+  "keywords": [
+    "password",
+    "vault",
+    "credentials",
+    "login",
+    "secure"
+  ],
+  "author": "Perry Mitchell <perry@perrymitchell.net>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/perry-mitchell/buttercup-core/issues"
+  },
+  "homepage": "https://github.com/perry-mitchell/buttercup-core#readme",
+  "dependencies": {
+    "clone": "~1.0.2",
+    "fs-symlink": "~1.2.1",
+    "gzip-js": "~0.3.2",
+    "pbkdf2": "~3.0.4",
+    "promise-polyfill": "~2.1.0",
+    "uuid": "~2.0.1",
+    "webdav-fs": "~0.3.0"
+  },
+  "devDependencies": {
+    "base64-img": "~1.0.3",
+    "istanbul": "^0.4.2",
+    "jsdoc-to-markdown": "~1.2.0",
+    "nodeunit": "~0.9.1",
+    "walk": "~2.3.9"
+  }
 }


### PR DESCRIPTION
This adds [istanbul](https://www.npmjs.com/package/istanbul) as a dev dependency so it can be used with `npm run test:istanbul`, rather than having to install a global package on their machines.